### PR TITLE
travis: require sudo, update OCaml compiler versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: c
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
+sudo: required
 env:
-  - PACKAGE="magic-mime" OCAML_VERSION=4.00
-  - PACKAGE="magic-mime" OCAML_VERSION=4.01 
+  - PACKAGE="magic-mime" OCAML_VERSION=4.02
+  - PACKAGE="magic-mime" OCAML_VERSION=4.03
   - PACKAGE="magic-mime" OCAML_VERSION=latest


### PR DESCRIPTION
The CI scripts require `sudo`.

This patch also targets OCaml 4.02 and 4.03 and latest which are more recent than 4.00 and 4.01.

Signed-off-by: David Scott <dave@recoil.org>