### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/magic-mime.opam
+++ b/magic-mime.opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/mirage/ocaml-magic-mime/issues"
 dev-repo: "git+https://github.com/mirage/ocaml-magic-mime.git"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
+  "dune"
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.