### PR TITLE
Use implicit executable dependency for generate_mime_types.exe

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -5,7 +5,7 @@
 
 (rule
  (targets mime_types.ml)
- (deps    ../generator/generate_mime_types.exe ../mime.types ../x-mime.types ../files.types)
+ (deps    ../mime.types ../x-mime.types ../files.types)
  (action  (with-stdout-to %{targets}
            (progn (run  ../generator/generate_mime_types.exe ../mime.types ../x-mime.types)
                   (run ../generator/generate_mime_types.exe ../files.types --files)))))


### PR DESCRIPTION
Explicit executable dependencies make dune fail in cross-compilation settings.
More info in https://github.com/ocaml/dune/issues/3917.
